### PR TITLE
Update params.env

### DIFF
--- a/config/manifests/bases/params.env
+++ b/config/manifests/bases/params.env
@@ -1,2 +1,2 @@
 namespace=opendatahub
-odh-codeflare-operator-controller-image=quay.io/project-codeflare/codeflare-operator:v1.0.0-rc.4
+odh-codeflare-operator-controller-image=quay.io/project-codeflare/codeflare-operator:v1.0.0


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
I noticed that when building and running the latest ODH operator it was still using rc4.

## How Has This Been Tested?
Built ODH:incubation branch with these manifest changes and ran on my cluster, ensuring that the v1.0.0 image was used and Ray Clusters are successfully deployed

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
