### PR TITLE
Add Makefile and configuration files for e2e execution on OpenShift CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -208,6 +208,11 @@ undeploy: ## Undeploy controller from the K8s cluster specified in ~/.kube/confi
 	$(KUSTOMIZE) build config/${ENV} | kubectl delete --ignore-not-found=$(ignore-not-found) -f -
 	git restore config/*
 
+.PHONY: install-odh-operator
+install-odh-operator: kustomize ## Install ODH operator into the OpenShift cluster specified in ~/.kube/config.
+	$(KUSTOMIZE) build config/odh-operator | kubectl apply -f -
+	kubectl wait -n openshift-operators subscription/opendatahub-operator --for=jsonpath='{.status.state}'=AtLatestKnown --timeout=180s
+
 ##@ Build Dependencies
 
 ## Location to install dependencies to
@@ -367,6 +372,17 @@ test-unit: manifests fmt vet envtest ## Run unit tests.
 .PHONY: test-e2e
 test-e2e: manifests fmt vet ## Run e2e tests.
 	go test -timeout 30m -v ./test/e2e
+
+.PHONY: test-odh
+test-odh: manifests fmt vet ## Run e2e ODH tests.
+	go test -timeout 60m -v ./test/odh
+
+.PHONY: store-odh-logs
+store-odh-logs: # Store all ODH relevant logs into artifact directory
+	kubectl logs -n opendatahub deployment/codeflare-operator-manager > ${ARTIFACT_DIR}/codeflare-operator.log
+	kubectl logs -n opendatahub deployment/kuberay-operator > ${ARTIFACT_DIR}/kuberay-operator.log
+	kubectl logs -n openshift-operators deployment/opendatahub-operator-controller-manager > ${ARTIFACT_DIR}/odh-operator.log
+	kubectl get events -n opendatahub > ${ARTIFACT_DIR}/odh-events.log
 
 .PHONY: kind-e2e
 kind-e2e: ## Set up e2e KinD cluster

--- a/config/odh-operator/kustomization.yaml
+++ b/config/odh-operator/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+- odh.yaml

--- a/config/odh-operator/odh.yaml
+++ b/config/odh-operator/odh.yaml
@@ -1,0 +1,13 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: opendatahub-operator
+  labels:
+    operators.coreos.com/opendatahub-operator.openshift-operators: ''
+  namespace: openshift-operators
+spec:
+  channel: fast
+  name: opendatahub-operator
+  installPlanApproval: Automatic
+  source: community-operators
+  sourceNamespace: openshift-marketplace

--- a/contrib/configuration/basic-dsc.yaml
+++ b/contrib/configuration/basic-dsc.yaml
@@ -1,0 +1,31 @@
+apiVersion: datasciencecluster.opendatahub.io/v1
+kind: DataScienceCluster
+metadata:
+  labels:
+    app.kubernetes.io/created-by: opendatahub-operator
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: datasciencecluster
+    app.kubernetes.io/part-of: opendatahub-operator
+  name: example-dsc
+spec:
+  components:
+    codeflare:
+      devFlags:
+        manifests:
+          - uri: '<CFO PR tarball URI>'
+            contextDir: 'config'
+            sourcePath: 'manifests'
+      managementState: Managed
+    dashboard:
+      managementState: Managed
+    datasciencepipelines:
+      managementState: Removed
+    kserve:
+      managementState: Removed
+    modelmeshserving:
+      managementState: Removed
+    ray:
+      managementState: Managed
+    workbenches:
+      managementState: Managed


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Providing Makefile and configuration files needed for openShift CI to get rid of dependency on DW repository.

The test execution in makefile is provided as composite target, so in case of test failure the logs can still be stored. For this functionality to work the Makefile needs to be invoked like this: `make -f Makefile.odh test-e2e --keep-going`

Storing operator logs and events here serves as a replacement for log removal in https://github.com/openshift/release/pull/45846 .

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually by invoking Makefile targets against own OCP cluster.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
