### PR TITLE
CARRY: Add workflow to release ODH/CFO with compiled test binaries

### DIFF
--- a/.github/workflows/odh-release.yml
+++ b/.github/workflows/odh-release.yml
@@ -1,0 +1,49 @@
+# This workflow will compile e2e tests and release them
+
+name: ODH Release
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Tag to be used for release, i.e.: v0.0.1'
+        required: true
+
+jobs:
+  release-odh:
+    runs-on: ubuntu-latest
+
+    # Permission required to create a release
+    permissions:
+      contents: write
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set Go
+      uses: actions/setup-go@v5
+      with:
+        go-version: v1.20
+
+    - name: Verify that release doesn't exist yet
+      shell: bash {0}
+      run: |
+        gh release view ${{ github.event.inputs.version }}
+        status=$?
+        if [[ $status -eq 0 ]]; then
+          echo "Release ${{ github.event.inputs.version }} already exists."
+          exit 1
+        fi
+      env:
+        GITHUB_TOKEN: ${{ github.TOKEN }}
+
+    - name: Compile tests
+      run: |
+        go test -c -o compiled-tests/e2e ./test/e2e/
+        go test -c -o compiled-tests/odh ./test/odh/
+
+    - name: Creates a release in GitHub
+      run: |
+        gh release create ${{ github.event.inputs.version }} --target ${{ github.ref }} compiled-tests/*
+      env:
+        GITHUB_TOKEN: ${{ secrets.CODEFLARE_MACHINE_ACCOUNT_TOKEN }}
+      shell: bash


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
As part of reducing downstream test execution time effort (https://issues.redhat.com/browse/RHOAIENG-3757) I would like to compile test binaries for every release and store them in GitHub release. These compiled binaries can be used for downstream testing, significantly reducing test time.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
