### PR TITLE
fix(manifestst): remove empty CRD folder and reference

### DIFF
--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -1,6 +1,0 @@
-# This kustomization.yaml is not intended to be run by itself,
-# since it depends on service name and namespace that are out of this kustomize package.
-# It should be run by config/default
-resources:
-
-#+kubebuilder:scaffold:crdkustomizeresource

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -14,7 +14,6 @@ commonLabels:
   app.kubernetes.io/part-of: codeflare
 
 bases:
-- ../crd
 - ../rbac
 - ../manager
 # [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
fix code sync from upstream [c771aae](https://github.com/opendatahub-io/codeflare-operator/commit/c771aae4dc990526b8b3b4d3817805fa479bded2) which is causing kustomize failing and ODH opeartor not functional 

error:
`Error: accumulating resources: accumulation err='accumulating resources from '../crd': '...../codeflare/crd' must resolve to a file': couldn't make target for path '.../codeflare/crd': kustomization.yaml is empty
`
## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
