### PR TITLE
Add workflow run for auto-merge sync

### DIFF
--- a/.github/workflows/auto-merge-sync.yaml
+++ b/.github/workflows/auto-merge-sync.yaml
@@ -1,0 +1,41 @@
+# Workflow is meant to run in the red-hat-data-services/codeflare-operator repo
+name: Auto-Merge-Sync
+on:
+  workflow_dispatch:
+
+jobs:
+  trigger-auto-merge-sync:
+    runs-on: ubuntu-latest
+    steps:
+    - name: upstream-odh-auto-merge
+      run: |
+        gh workflow run upstream-auto-merge.yaml --repo github.com/red-hat-data-services/rhods-devops-infra --ref main --field repositories=codeflare-upstream
+        sleep 5
+        run_id=$(gh run list --workflow upstream-auto-merge.yaml --repo github.com/red-hat-data-services/rhods-devops-infra --limit 1 --json databaseId --jq .[].databaseId)
+        gh run watch ${run_id} --repo github.com/red-hat-data-services/rhods-devops-infra --interval 10 --exit-status
+      env:
+        GITHUB_TOKEN: ${{ secrets.PAT_TOKEN }}
+      shell:
+        bash
+    - name: odh-rhds-auto-merge
+      if: ${{ success()}}
+      run: |
+        gh workflow run upstream-auto-merge.yaml --repo github.com/red-hat-data-services/rhods-devops-infra --ref main --field repositories=codeflare-downstream
+        sleep 5
+        run_id=$(gh run list --workflow upstream-auto-merge.yaml --repo github.com/red-hat-data-services/rhods-devops-infra --limit 1 --json databaseId --jq .[].databaseId)
+        gh run watch ${run_id} --repo github.com/red-hat-data-services/rhods-devops-infra --interval 10 --exit-status
+      env:
+        GITHUB_TOKEN: ${{ secrets.PAT_TOKEN }}
+      shell:
+        bash
+    - name: rhds-release-auto-merge
+      if: ${{ success()}}
+      run: |
+        gh workflow run main-release-auto-merge.yaml --repo github.com/red-hat-data-services/rhods-devops-infra --ref main --field repositories=codeflare-operator
+        sleep 5
+        run_id=$(gh run list --workflow main-release-auto-merge.yaml --repo github.com/red-hat-data-services/rhods-devops-infra --limit 1 --json databaseId --jq .[].databaseId)
+        gh run watch ${run_id} --repo github.com/red-hat-data-services/rhods-devops-infra --interval 10 --exit-status
+      env:
+        GITHUB_TOKEN: ${{ secrets.PAT_TOKEN }}
+      shell:
+        bash


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This workflow will invoke the [`upstream-auto-merge.yaml` workflow](https://github.com/red-hat-data-services/rhods-devops-infra/blob/main/.github/workflows/upstream-auto-merge.yaml) in the rhods-devops-infra repository. 
This workflow will first sync changes from `upstream>ODH`, then `ODH>RHDS`, then RHDS>>rhoai latest release branch.

This workflow is meant to run on the red-hat-data-services/CFO repository. The `red-hat-data-services/rhods-devops-infra` repo is private. It seems GitHub only allows repos from the same org (red-hat-data-services) to invoke a workflow in private repos.

Using `PAT_TOKEN` which I created and added to the red-hat-data-services/codeflare-operator secrets. This is until we have a shared token.


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
