### PR TITLE
Add the component_metadata.yaml file to track codeflare-operator relase

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ For ODH tests additional environment variables are needed:
 6. In ODH/CFO verify that the [Build and Push action](https://github.com/opendatahub-io/codeflare-operator/actions/workflows/build-and-push.yaml) was triggered and ran successfully.
 7. Make sure that release automation created a PR updating CodeFlare SDK version in [ODH Notebooks repository](https://github.com/opendatahub-io/notebooks). Make sure the PR gets merged.
 8. Run [ODH CodeFlare Operator release workflow](https://github.com/opendatahub-io/codeflare-operator/actions/workflows/odh-release.yml) to produce ODH CodeFlare Operator release.
+9. Ensure that the version details in the `config/component_metadata.yaml` file are updated to reflect the latest upstream CodeFlare Operator release version
 
 ### Releases involving part of the stack
 

--- a/config/component_metadata.yaml
+++ b/config/component_metadata.yaml
@@ -1,0 +1,4 @@
+releases:
+  - name: CodeFlare operator
+    version: 1.12.0
+    repoUrl: https://github.com/project-codeflare/codeflare-operator


### PR DESCRIPTION
closes https://issues.redhat.com/browse/RHOAIENG-16452 
<!--- Provide a general summary of your changes in the Title above -->
Added the component_metadata.yaml file to track codeflare-operator release version.
## Description
<!--- Describe your changes in detail -->
This PR introduces a new file component_metadata.yaml to track codeflare-operator releases . This was a request by the Platform team so they can fetch it to ODH operator and expose in the DSCI



## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
