### PR TITLE
CARRY: Update Codeflare Operator image to new ODH Konflux image

### DIFF
--- a/config/manager/params.env
+++ b/config/manager/params.env
@@ -1,2 +1,2 @@
-codeflare-operator-controller-image=quay.io/opendatahub/codeflare-operator:v1.16.0
+codeflare-operator-controller-image=quay.io/opendatahub/odh-codeflare-operator:v1.16.0
 namespace=opendatahub


### PR DESCRIPTION
Updating here to use this image for ODH: quay.io/opendatahub/odh-codeflare-operator:v1.16.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the container image reference for the codeflare operator.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->