### PR TITLE
fix(RHOAIENG-68496): reduce secrets RBAC to minimum required verbs

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -119,11 +119,8 @@ rules:
   - secrets
   verbs:
   - create
-  - delete
   - get
-  - list
   - patch
-  - watch
 - apiGroups:
   - ""
   resources:

--- a/pkg/controllers/raycluster_controller.go
+++ b/pkg/controllers/raycluster_controller.go
@@ -95,7 +95,7 @@ var (
 // +kubebuilder:rbac:groups=ray.io,resources=rayclusters/finalizers,verbs=update
 // +kubebuilder:rbac:groups=route.openshift.io,resources=routes;routes/custom-host,verbs=get;list;create;update;patch;delete;watch
 // +kubebuilder:rbac:groups=networking.k8s.io,resources=ingresses,verbs=get;list;create;update;patch;delete;watch
-// +kubebuilder:rbac:groups=core,resources=secrets,verbs=get;list;create;patch;delete;get;watch
+// +kubebuilder:rbac:groups=core,resources=secrets,verbs=get;create;patch
 // +kubebuilder:rbac:groups=core,resources=services,verbs=get;list;create;update;patch;delete;watch
 // +kubebuilder:rbac:groups=core,resources=serviceaccounts,verbs=get;list;create;update;patch;delete;watch
 // +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterrolebindings,verbs=get;list;create;update;patch;delete;watch
@@ -680,7 +680,6 @@ func (r *RayClusterReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		For(&rayv1.RayCluster{}).
 		Owns(&corev1.ServiceAccount{}).
 		Owns(&corev1.Service{}).
-		Owns(&corev1.Secret{}).
 		Owns(&networkingv1.Ingress{}).
 		Owns(&networkingv1.NetworkPolicy{}).
 		Watches(&rbacv1.ClusterRoleBinding{}, handler.EnqueueRequestsFromMapFunc(


### PR DESCRIPTION
## Description

Remove `delete`, `list`, and `watch` from the raycluster controller's secrets RBAC marker and remove the `.Owns(&corev1.Secret{})` watch registration. The controller only uses Get, Apply (create+patch) on secrets via a direct typed client — it never deletes secrets or relies on informer-driven reconciliation from secret changes.

The cert-controller's separate marker (`get`/`list`/`watch`/`update`) remains unchanged as those verbs are required by its namespaced cache and Update-based cert rotation.

**Net effect on the generated ClusterRole:** the second secrets rule block drops from `[create, delete, get, list, patch, watch]` to `[create, get, patch]`.

**Jira:** [RHOAIENG-68496](https://redhat.atlassian.net/browse/RHOAIENG-68496)

## How Has This Been Tested?

- Unit tests pass (`make test-unit` — 35 tests, 0 failures, 72.7% coverage)
- Confirmed `config/rbac/role.yaml` regenerates cleanly with `make manifests` and matches the committed file

## Merge criteria:
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work

[RHOAIENG-68496]: https://redhat.atlassian.net/browse/RHOAIENG-68496?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Restricted secret access to only the permissions required to retrieve, create, and update secrets.
  * Removed automatic reconciliation triggers for secret changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->